### PR TITLE
feat: Add sign-out and navigation to Home icon

### DIFF
--- a/app/src/main/java/com/example/aerogcsclone/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/example/aerogcsclone/navigation/AppNavGraph.kt
@@ -45,7 +45,7 @@ fun AppNavGraph(navController: NavHostController) {
             )
         }
         composable(Screen.Main.route) {
-            MainPage(telemetryViewModel = sharedViewModel)
+            MainPage(telemetryViewModel = sharedViewModel, authViewModel = authViewModel, navController = navController)
         }
     }
 }

--- a/app/src/main/java/com/example/aerogcsclone/uimain/MainPage.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/MainPage.kt
@@ -13,10 +13,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
 import com.example.aerogcsclone.Telemetry.SharedViewModel
+import com.example.aerogcsclone.authentication.AuthViewModel
 
 @Composable
-fun MainPage(telemetryViewModel: SharedViewModel) {
+fun MainPage(telemetryViewModel: SharedViewModel, authViewModel: AuthViewModel, navController: NavHostController) {
     val telemetryState by telemetryViewModel.telemetryState.collectAsState()
 
     Column(
@@ -24,7 +26,7 @@ fun MainPage(telemetryViewModel: SharedViewModel) {
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
     ) {
-        TopNavBar(telemetryState)
+        TopNavBar(telemetryState = telemetryState, authViewModel = authViewModel, navController = navController)
 
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/example/aerogcsclone/uimain/TopNavBar.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/TopNavBar.kt
@@ -17,10 +17,13 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
 import com.example.aerogcsclone.Telemetry.TelemetryState
+import com.example.aerogcsclone.authentication.AuthViewModel
+import com.example.aerogcsclone.navigation.Screen
 
 @Composable
-fun TopNavBar(telemetryState: TelemetryState) {
+fun TopNavBar(telemetryState: TelemetryState, authViewModel: AuthViewModel, navController: NavHostController) {
     var menuExpanded by remember { mutableStateOf(false) }
     var selectedMode by remember { mutableStateOf("Manual") }
     Box(
@@ -80,7 +83,14 @@ fun TopNavBar(telemetryState: TelemetryState) {
                 }
             }
             Spacer(modifier = Modifier.width(12.dp))
-            Icon(Icons.Default.Home, contentDescription = "Home", tint = Color.White)
+            Icon(Icons.Default.Home, contentDescription = "Home", tint = Color.White, modifier = Modifier.clickable {
+                authViewModel.signout()
+                navController.navigate(Screen.Login.route) {
+                    popUpTo(Screen.Main.route) {
+                        inclusive = true
+                    }
+                }
+            })
             Spacer(modifier = Modifier.width(16.dp))
 
             Column(


### PR DESCRIPTION
- Modified TopNavBar.kt to accept AuthViewModel and NavHostController.
- Added a clickable modifier to the Home icon to trigger Firebase sign-out and navigate to the Login screen.
- Updated MainPage.kt and AppNavGraph.kt to pass the necessary dependencies.