### PR TITLE
feat: Update Home icon to navigate to Connection screen

### DIFF
--- a/app/src/main/java/com/example/aerogcsclone/uimain/TopNavBar.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/TopNavBar.kt
@@ -84,12 +84,7 @@ fun TopNavBar(telemetryState: TelemetryState, authViewModel: AuthViewModel, navC
             }
             Spacer(modifier = Modifier.width(12.dp))
             Icon(Icons.Default.Home, contentDescription = "Home", tint = Color.White, modifier = Modifier.clickable {
-                authViewModel.signout()
-                navController.navigate(Screen.Login.route) {
-                    popUpTo(Screen.Main.route) {
-                        inclusive = true
-                    }
-                }
+                navController.navigate(Screen.Connection.route)
             })
             Spacer(modifier = Modifier.width(16.dp))
 


### PR DESCRIPTION
The Home icon in the TopNavBar previously signed the user out and navigated to the Login page. This commit changes this behavior to navigate directly to the Connection screen without signing the user out.