### PR TITLE
feat: implement logout and navigation to login screen

### DIFF
--- a/app/src/main/java/com/example/aerogcsclone/uimain/TopNavBar.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/TopNavBar.kt
@@ -162,7 +162,13 @@ fun TopNavBar(telemetryState: TelemetryState, authViewModel: AuthViewModel, navC
                         )
                         DropdownMenuItem(
                             text = { Text("Logout") },
-                            onClick = { kebabMenuExpanded = false }
+                            onClick = {
+                                kebabMenuExpanded = false
+                                authViewModel.signout()
+                                navController.navigate(Screen.Login.route) {
+                                    popUpTo(0)
+                                }
+                            }
                         )
                     }
                 }


### PR DESCRIPTION
This commit updates the 'Logout' menu item in the `TopNavBar` to sign out the user and navigate them to the `LoginScreen`.

The `onClick` handler for the 'Logout' `DropdownMenuItem` in `TopNavBar.kt` has been modified to:
1. Call the `signout()` method from the `AuthViewModel`.
2. Navigate to the `LoginScreen` using the `navController`.
3. Clear the back stack to prevent the user from returning to the main screen after logging out.