### PR TITLE
feat: Add Plan Screen and navigation

### DIFF
--- a/app/src/main/java/com/example/aerogcsclone/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/example/aerogcsclone/navigation/AppNavGraph.kt
@@ -11,12 +11,14 @@ import com.example.aerogcsclone.authentication.LoginPage
 import com.example.aerogcsclone.authentication.SignupPage
 import com.example.aerogcsclone.uiconnection.ConnectionPage
 import com.example.aerogcsclone.uimain.MainPage
+import com.example.aerogcsclone.uimain.PlanScreen
 
 sealed class Screen(val route: String) {
     object Connection : Screen("connection")
     object Main : Screen("main")
     object Login : Screen("login")
     object Signup : Screen("signup")
+    object Plan : Screen("plan")
 }
 
 @Composable
@@ -46,6 +48,9 @@ fun AppNavGraph(navController: NavHostController) {
         }
         composable(Screen.Main.route) {
             MainPage(telemetryViewModel = sharedViewModel, authViewModel = authViewModel, navController = navController)
+        }
+        composable(Screen.Plan.route) {
+            PlanScreen(telemetryViewModel = sharedViewModel, authViewModel = authViewModel, navController = navController)
         }
     }
 }

--- a/app/src/main/java/com/example/aerogcsclone/uimain/PlanScreen.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/PlanScreen.kt
@@ -1,0 +1,45 @@
+package com.example.aerogcsclone.uimain
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import com.example.aerogcsclone.Telemetry.SharedViewModel
+import com.example.aerogcsclone.authentication.AuthViewModel
+
+@Composable
+fun PlanScreen(
+    telemetryViewModel: SharedViewModel,
+    authViewModel: AuthViewModel,
+    navController: NavHostController
+) {
+    val telemetryState by telemetryViewModel.telemetryState.collectAsState()
+
+    Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(onClick = { /* TODO */ }) {
+                Text("Create Plan")
+            }
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            TopNavBar(
+                telemetryState = telemetryState,
+                authViewModel = authViewModel,
+                navController = navController
+            )
+            GcsMap()
+        }
+    }
+}

--- a/app/src/main/java/com/example/aerogcsclone/uimain/TopNavBar.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/TopNavBar.kt
@@ -59,23 +59,27 @@ fun TopNavBar(telemetryState: TelemetryState, authViewModel: AuthViewModel, navC
                         Column(
                             modifier = Modifier
                                 .background(Color.Black.copy(alpha = 0.5f))
+                                .width(180.dp) // Increased width
                                 .padding(vertical = 8.dp, horizontal = 16.dp)
                         ) {
                             Text(
                                 text = "Automatic",
                                 color = Color.White,
+                                fontSize = 22.sp, // Increased font size
                                 modifier = Modifier
-                                    .padding(8.dp)
+                                    .padding(16.dp) // Increased padding
                                     .clickable {
                                         selectedMode = "Automatic"
                                         menuExpanded = false
+                                        navController.navigate(Screen.Plan.route)
                                     }
                             )
                             Text(
                                 text = "Manual",
                                 color = Color.White,
+                                fontSize = 22.sp, // Increased font size
                                 modifier = Modifier
-                                    .padding(8.dp)
+                                    .padding(16.dp) // Increased padding
                                     .clickable {
                                         selectedMode = "Manual"
                                         menuExpanded = false


### PR DESCRIPTION
This commit introduces a new 'Plan Screen' which is accessed by clicking the 'Automatic' option in the top navigation bar menu.

The Plan Screen includes the top navigation bar, a map view, and a 'Create Plan' floating action button.

The navigation graph has been updated to include the new screen, and the top navigation bar has been modified to trigger the navigation.