### PR TITLE
feat: Set splash screen background to white

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,7 +6,7 @@
     <!-- Splash Screen Theme. -->
     <style name="Theme.App.Starting" parent="Theme.SplashScreen">
         <!-- Set the splash screen background, animated icon, and destination theme. -->
-        <item name="windowSplashScreenBackground">@android:color/black</item>
+        <item name="windowSplashScreenBackground">@color/white</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/pavaman_logo</item>
         <item name="postSplashScreenTheme">@style/Theme.Aerogcsclone</item>
     </style>


### PR DESCRIPTION
This commit updates the splash screen theme to use a white background. This ensures that the splash screen is always in light mode, even if the system is in dark mode.