### PR TITLE
feat: Update text color to black on Login and Signup screens

### DIFF
--- a/app/src/main/java/com/example/aerogcsclone/authentication/LoginPage.kt
+++ b/app/src/main/java/com/example/aerogcsclone/authentication/LoginPage.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
@@ -66,15 +67,24 @@ fun LoginPage(modifier: Modifier = Modifier, navController: NavController, authV
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
-                Text(text = "Login with pavaman", fontSize = 32.sp)
-                Text(text = "Login with pavaman credentials", fontSize = 12.sp)
+                Text(text = "Login with pavaman", fontSize = 32.sp, color = Color.Black)
+                Text(text = "Login with pavaman credentials", fontSize = 12.sp, color = Color.Black)
 
                 Spacer(modifier = Modifier.height(16.dp))
 
                 OutlinedTextField(
                     value = email,
                     onValueChange = { email = it },
-                    label = { Text(text = "Email") }
+                    label = { Text(text = "Email") },
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = Color.Black,
+                        unfocusedTextColor = Color.Black,
+                        cursorColor = Color.Black,
+                        focusedBorderColor = Color.Black,
+                        unfocusedBorderColor = Color.Black,
+                        focusedLabelColor = Color.Black,
+                        unfocusedLabelColor = Color.Black
+                    )
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -82,22 +92,30 @@ fun LoginPage(modifier: Modifier = Modifier, navController: NavController, authV
                 OutlinedTextField(
                     value = password,
                     onValueChange = { password = it },
-                    label = { Text(text = "Password") }
+                    label = { Text(text = "Password") },
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = Color.Black,
+                        unfocusedTextColor = Color.Black,
+                        cursorColor = Color.Black,
+                        focusedBorderColor = Color.Black,
+                        unfocusedBorderColor = Color.Black,
+                        focusedLabelColor = Color.Black,
+                        unfocusedLabelColor = Color.Black
+                    )
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
 
                 Button(onClick = { authViewModel.login(email, password) }) {
-                    Text(text = "Login")
+                    Text(text = "Login", color = Color.Black)
                 }
 
                 Spacer(modifier = Modifier.height(8.dp))
 
                 TextButton(onClick = { navController.navigate(Screen.Signup.route) }) {
-                    Text(text = "Signup")
+                    Text(text = "Signup", color = Color.Black)
                 }
             }
         }
     }
 }
-

--- a/app/src/main/java/com/example/aerogcsclone/authentication/SignupPage.kt
+++ b/app/src/main/java/com/example/aerogcsclone/authentication/SignupPage.kt
@@ -1,7 +1,6 @@
 package com.example.aerogcsclone.authentication
 
 import android.widget.Toast
-import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -10,6 +9,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
@@ -67,15 +67,24 @@ fun SignupPage(modifier: Modifier = Modifier, navController: NavController, auth
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
-                Text(text = "Signup with Pavaman", fontSize = 32.sp)
-                Text(text = "Create your custom mail and password", fontSize = 12.sp)
+                Text(text = "Signup with Pavaman", fontSize = 32.sp, color = Color.Black)
+                Text(text = "Create your custom mail and password", fontSize = 12.sp, color = Color.Black)
 
                 Spacer(modifier = Modifier.height(16.dp))
 
                 OutlinedTextField(
                     value = email,
                     onValueChange = { email = it },
-                    label = { Text(text = "Email") }
+                    label = { Text(text = "Email") },
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = Color.Black,
+                        unfocusedTextColor = Color.Black,
+                        cursorColor = Color.Black,
+                        focusedBorderColor = Color.Black,
+                        unfocusedBorderColor = Color.Black,
+                        focusedLabelColor = Color.Black,
+                        unfocusedLabelColor = Color.Black
+                    )
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -83,19 +92,28 @@ fun SignupPage(modifier: Modifier = Modifier, navController: NavController, auth
                 OutlinedTextField(
                     value = password,
                     onValueChange = { password = it },
-                    label = { Text(text = "Password") }
+                    label = { Text(text = "Password") },
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = Color.Black,
+                        unfocusedTextColor = Color.Black,
+                        cursorColor = Color.Black,
+                        focusedBorderColor = Color.Black,
+                        unfocusedBorderColor = Color.Black,
+                        focusedLabelColor = Color.Black,
+                        unfocusedLabelColor = Color.Black
+                    )
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
 
                 Button(onClick = { authViewModel.signup(email, password) }) {
-                    Text(text = "Create account")
+                    Text(text = "Create account", color = Color.Black)
                 }
 
                 Spacer(modifier = Modifier.height(8.dp))
 
                 TextButton(onClick = { navController.navigate(Screen.Login.route) }) {
-                    Text(text = "if already have an account, Login")
+                    Text(text = "if already have an account, Login", color = Color.Black)
                 }
             }
         }


### PR DESCRIPTION
This commit updates the `LoginPage.kt` and `SignupPage.kt` files to display all text in black. This includes titles, labels, placeholders, and button text.

The changes were made by explicitly setting the color of the `Text` composables to `Color.Black` and by using `OutlinedTextFieldDefaults.colors` to set the color of the text, labels, and borders of the `OutlinedTextField` composables to black.