### PR TITLE
feat: Implement mission planning screen

### DIFF
--- a/app/src/main/java/com/example/aerogcsclone/Telemetry/Data.kt
+++ b/app/src/main/java/com/example/aerogcsclone/Telemetry/Data.kt
@@ -24,4 +24,5 @@ data class TelemetryState(
     val mode: String? = null,
     val armed: Boolean = false,
     val armable: Boolean = false,
+    val missionLoaded: Boolean = false,
 )

--- a/app/src/main/java/com/example/aerogcsclone/Telemetry/SharedViewModel.kt
+++ b/app/src/main/java/com/example/aerogcsclone/Telemetry/SharedViewModel.kt
@@ -5,10 +5,19 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.aerogcsclone.uimain.Geometry
+import com.google.android.gms.maps.model.LatLng
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 class SharedViewModel : ViewModel() {
+
+    var waypoints by mutableStateOf(listOf<LatLng>())
+        private set
+
+    fun addWaypoint(latLng: LatLng) {
+        waypoints = waypoints + latLng
+    }
 
     var ipAddress by mutableStateOf("10.0.2.2")
     var port by mutableStateOf("5762")
@@ -40,5 +49,33 @@ class SharedViewModel : ViewModel() {
         viewModelScope.launch {
             repo?.arm()
         }
+    }
+
+    fun loadMission() {
+        viewModelScope.launch {
+            repo?.loadMission(waypoints)
+        }
+    }
+
+    fun startMission() {
+        viewModelScope.launch {
+            repo?.startMission()
+        }
+    }
+
+    fun resetMissionLoaded() {
+        // This is not ideal, we should be updating the state in the repo
+        // and have it flow up, but for now this will do.
+        _telemetryState.update { it.copy(missionLoaded = false) }
+    }
+
+    fun deleteLastWaypoint() {
+        if (waypoints.isNotEmpty()) {
+            waypoints = waypoints.dropLast(1)
+        }
+    }
+
+    fun clearAllWaypoints() {
+        waypoints = emptyList()
     }
 }

--- a/app/src/main/java/com/example/aerogcsclone/uimain/GcsMap.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/GcsMap.kt
@@ -1,7 +1,12 @@
 package com.example.aerogcsclone.uimain
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.example.aerogcsclone.Telemetry.TelemetryState
 import com.google.android.gms.maps.CameraUpdateFactory
@@ -9,70 +14,54 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.*
 
 @Composable
-fun GcsMap(telemetryState: TelemetryState) {
-    var points by remember { mutableStateOf(listOf<LatLng>()) }
-    var polygonClosed by remember { mutableStateOf(false) }
+fun GcsMap(
+    telemetryState: TelemetryState,
+    cameraPositionState: CameraPositionState,
+    waypoints: List<LatLng>,
+    showCrosshair: Boolean = false
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        GoogleMap(
+            modifier = Modifier.fillMaxSize(),
+            cameraPositionState = cameraPositionState,
+        ) {
+            // Live drone marker
+            val lat = telemetryState.latitude
+            val lon = telemetryState.longitude
+            if (lat != null && lon != null) {
+                Marker(
+                    state = MarkerState(position = LatLng(lat, lon)),
+                    title = "Drone Location"
+                )
+            }
 
-    val cameraPositionState = rememberCameraPositionState()
+            // Waypoint markers
+            waypoints.forEachIndexed { index, waypoint ->
+                Marker(
+                    state = MarkerState(position = waypoint),
+                    title = "Waypoint ${index + 1}"
+                )
+            }
 
-    // Update camera when telemetry changes (live location)
-    LaunchedEffect(telemetryState.latitude, telemetryState.longitude) {
-        val lat = telemetryState.latitude
-        val lon = telemetryState.longitude
-        if (lat != null && lon != null) {
-            val newPosition = LatLng(lat, lon)
-            cameraPositionState.animate(
-                update = CameraUpdateFactory.newLatLngZoom(newPosition, 16f),
-                durationMs = 1000
-            )
-        }
-    }
-
-    GoogleMap(
-        modifier = Modifier.fillMaxSize(),
-        cameraPositionState = cameraPositionState,
-        onMapClick = { latLng ->
-            if (!polygonClosed) {
-                points = points + latLng
+            // Draw polyline between waypoints
+            if (waypoints.size > 1) {
+                val polylinePoints = if (waypoints.size >= 3) {
+                    waypoints + waypoints.first()
+                } else {
+                    waypoints
+                }
+                Polyline(
+                    points = polylinePoints,
+                    width = 4f
+                )
             }
         }
-    ) {
-        // Live drone marker
-        val lat = telemetryState.latitude
-        val lon = telemetryState.longitude
-        if (lat != null && lon != null) {
-            Marker(
-                state = MarkerState(position = LatLng(lat, lon)),
-                title = "Drone Location"
-            )
-        }
 
-        // User-drawn markers
-        points.forEachIndexed { index, point ->
-            Marker(
-                state = MarkerState(position = point),
-                title = "Marker ${index + 1}",
-                onClick = {
-                    if (points.size > 1 && !polygonClosed) {
-                        val last = points.last()
-
-                        if (point == points.first() && points.size > 2) {
-                            points = points + point
-                            polygonClosed = true
-                        } else if (point != last) {
-                            points = points + point
-                        }
-                    }
-                    true
-                }
-            )
-        }
-
-        // Draw polyline (open or closed)
-        if (points.size > 1) {
-            Polyline(
-                points = points,
-                width = 4f
+        if (showCrosshair) {
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = "Crosshair",
+                modifier = Modifier.align(Alignment.Center)
             )
         }
     }

--- a/app/src/main/java/com/example/aerogcsclone/uimain/MainPage.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/MainPage.kt
@@ -17,6 +17,8 @@ import androidx.navigation.NavHostController
 import com.example.aerogcsclone.Telemetry.SharedViewModel
 import com.example.aerogcsclone.Telemetry.TelemetryState
 import com.example.aerogcsclone.authentication.AuthViewModel
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.rememberCameraPositionState
 
 @Composable
 fun MainPage(
@@ -25,6 +27,7 @@ fun MainPage(
     navController: NavHostController
 ) {
     val telemetryState by telemetryViewModel.telemetryState.collectAsState()
+    val cameraPositionState = rememberCameraPositionState()
 
     Column(
         modifier = Modifier
@@ -44,10 +47,12 @@ fun MainPage(
                 .fillMaxWidth()
         ) {
             // ✅ Pass telemetryState to GcsMap
-//
-            GcsMap(telemetryState = telemetryState)
-
-
+            GcsMap(
+                telemetryState = telemetryState,
+                cameraPositionState = cameraPositionState,
+                waypoints = telemetryViewModel.waypoints,
+                showCrosshair = false
+            )
 
             StatusPanel(
                 modifier = Modifier
@@ -59,7 +64,9 @@ fun MainPage(
             FloatingButtons(
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
-                    .padding(12.dp)
+                    .padding(12.dp),
+                telemetryViewModel = telemetryViewModel,
+                telemetryState = telemetryState
             )
         }
     }
@@ -105,16 +112,25 @@ fun StatusPanel(
 }
 
 @Composable
-fun FloatingButtons(modifier: Modifier = Modifier) {
+fun FloatingButtons(
+    modifier: Modifier = Modifier,
+    telemetryViewModel: SharedViewModel,
+    telemetryState: TelemetryState
+) {
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(12.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        FloatingActionButton(onClick = { }, containerColor = Color.Black.copy(alpha = 0.7f)) {
-            Icon(Icons.Default.PlayArrow, contentDescription = "Start", tint = Color.White)
+        if (telemetryState.missionLoaded) {
+            FloatingActionButton(
+                onClick = { telemetryViewModel.startMission() },
+                containerColor = Color.Black.copy(alpha = 0.7f)
+            ) {
+                Icon(Icons.Default.PlayArrow, contentDescription = "Start Mission", tint = Color.White)
+            }
         }
-        FloatingActionButton(onClick = { }, containerColor = Color.Black.copy(alpha = 0.7f)) {
+        FloatingActionButton(onClick = { /*TODO: Implement settings*/ }, containerColor = Color.Black.copy(alpha = 0.7f)) {
             Icon(Icons.Default.Settings, contentDescription = "Settings", tint = Color.White)
         }
         FloatingActionButton(onClick = { }, containerColor = Color.Black.copy(alpha = 0.7f)) {

--- a/app/src/main/java/com/example/aerogcsclone/uimain/PlanScreen.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/PlanScreen.kt
@@ -12,11 +12,10 @@ import com.example.aerogcsclone.Telemetry.SharedViewModel
 import com.example.aerogcsclone.authentication.AuthViewModel
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Build
-import androidx.compose.material.icons.filled.FlightTakeoff
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.ClearAll
-import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.*
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.rememberCameraPositionState
 
 @Composable
 fun PlanScreen(
@@ -28,6 +27,28 @@ fun PlanScreen(
 
     // State to toggle plan action buttons
     var showPlanActions by remember { mutableStateOf(false) }
+    val cameraPositionState = rememberCameraPositionState()
+
+    // Update camera when telemetry changes (live location)
+    LaunchedEffect(telemetryState.latitude, telemetryState.longitude) {
+        val lat = telemetryState.latitude
+        val lon = telemetryState.longitude
+        if (lat != null && lon != null) {
+            val newPosition = LatLng(lat, lon)
+            cameraPositionState.animate(
+                update = CameraUpdateFactory.newLatLngZoom(newPosition, 16f),
+                durationMs = 1000
+            )
+        }
+    }
+
+    // Navigate back when mission is loaded
+    LaunchedEffect(telemetryState.missionLoaded) {
+        if (telemetryState.missionLoaded) {
+            navController.popBackStack()
+            telemetryViewModel.resetMissionLoaded()
+        }
+    }
 
     Scaffold(
         floatingActionButton = {
@@ -37,7 +58,10 @@ fun PlanScreen(
                 // Extra buttons shown above "Create Plan"
                 if (showPlanActions) {
                     FloatingActionButton(
-                        onClick = { /* TODO: Add Waypoints */ },
+                        onClick = {
+                            val center = cameraPositionState.position.target
+                            telemetryViewModel.addWaypoint(center)
+                        },
                         modifier = Modifier
                             .padding(bottom = 12.dp)
                             .size(56.dp)
@@ -46,21 +70,30 @@ fun PlanScreen(
                     }
 
                     FloatingActionButton(
-                        onClick = { /* TODO: Delete Waypoints */ },
+                        onClick = { telemetryViewModel.deleteLastWaypoint() },
                         modifier = Modifier
                             .padding(bottom = 12.dp)
                             .size(56.dp)
                     ) {
-                        Icon(Icons.Default.Delete, contentDescription = "Delete Waypoints")
+                        Icon(Icons.Default.Delete, contentDescription = "Delete Last Waypoint")
                     }
 
                     FloatingActionButton(
-                        onClick = { /* TODO: Clear Plan */ },
+                        onClick = { telemetryViewModel.clearAllWaypoints() },
                         modifier = Modifier
                             .padding(bottom = 12.dp)
                             .size(56.dp)
                     ) {
                         Icon(Icons.Default.ClearAll, contentDescription = "Clear Plan")
+                    }
+
+                    FloatingActionButton(
+                        onClick = { telemetryViewModel.loadMission() },
+                        modifier = Modifier
+                            .padding(bottom = 12.dp)
+                            .size(56.dp)
+                    ) {
+                        Icon(Icons.Default.Publish, contentDescription = "Load Mission")
                     }
                 }
 
@@ -88,7 +121,12 @@ fun PlanScreen(
 
             Box(modifier = Modifier.fillMaxSize()) {
                 // Map background
-                GcsMap(telemetryState = telemetryState)
+                GcsMap(
+                    telemetryState = telemetryState,
+                    cameraPositionState = cameraPositionState,
+                    waypoints = telemetryViewModel.waypoints,
+                    showCrosshair = true
+                )
 
                 // Left-side floating buttons (below TopNavBar)
                 Column(


### PR DESCRIPTION
This commit introduces a new mission planning screen that allows users to create and upload missions to a drone.

The key features of this implementation are:

- A new "Plan" tab with a map view.
- A crosshair in the center of the map for accurate waypoint placement.
- Floating action buttons to add, delete, and clear waypoints.
- A "Load Mission" button that sends the waypoints to the drone's flight controller using the MAVLink mission protocol.
- A "Start Mission" button that appears on the main screen after a mission has been successfully loaded.
- The map displays the waypoints and a closed polygon representing the mission area.