### PR TITLE
feat: Add map type toggle functionality

### DIFF
--- a/app/src/main/java/com/example/aerogcsclone/uimain/GcsMap.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/GcsMap.kt
@@ -9,7 +9,10 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.*
 
 @Composable
-fun GcsMap(telemetryState: TelemetryState) {
+fun GcsMap(
+    telemetryState: TelemetryState,
+    properties: MapProperties = MapProperties(),
+) {
     var points by remember { mutableStateOf(listOf<LatLng>()) }
     var polygonClosed by remember { mutableStateOf(false) }
 
@@ -31,6 +34,7 @@ fun GcsMap(telemetryState: TelemetryState) {
     GoogleMap(
         modifier = Modifier.fillMaxSize(),
         cameraPositionState = cameraPositionState,
+        properties = properties,
         onMapClick = { latLng ->
             if (!polygonClosed) {
                 points = points + latLng

--- a/app/src/main/java/com/example/aerogcsclone/uimain/MainPage.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/MainPage.kt
@@ -6,9 +6,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -17,6 +15,8 @@ import androidx.navigation.NavHostController
 import com.example.aerogcsclone.Telemetry.SharedViewModel
 import com.example.aerogcsclone.Telemetry.TelemetryState
 import com.example.aerogcsclone.authentication.AuthViewModel
+import com.google.maps.android.compose.MapProperties
+import com.google.maps.android.compose.MapType
 
 @Composable
 fun MainPage(
@@ -25,6 +25,9 @@ fun MainPage(
     navController: NavHostController
 ) {
     val telemetryState by telemetryViewModel.telemetryState.collectAsState()
+    var mapProperties by remember {
+        mutableStateOf(MapProperties(mapType = MapType.NORMAL))
+    }
 
     Column(
         modifier = Modifier
@@ -44,8 +47,10 @@ fun MainPage(
                 .fillMaxWidth()
         ) {
             // ✅ Pass telemetryState to GcsMap
-//
-            GcsMap(telemetryState = telemetryState)
+            GcsMap(
+                telemetryState = telemetryState,
+                properties = mapProperties
+            )
 
 
 
@@ -59,7 +64,12 @@ fun MainPage(
             FloatingButtons(
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
-                    .padding(12.dp)
+                    .padding(12.dp),
+                onMapTypeChange = {
+                    mapProperties = mapProperties.copy(
+                        mapType = if (mapProperties.mapType == MapType.NORMAL) MapType.SATELLITE else MapType.NORMAL
+                    )
+                }
             )
         }
     }
@@ -105,7 +115,10 @@ fun StatusPanel(
 }
 
 @Composable
-fun FloatingButtons(modifier: Modifier = Modifier) {
+fun FloatingButtons(
+    modifier: Modifier = Modifier,
+    onMapTypeChange: () -> Unit
+) {
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -120,7 +133,7 @@ fun FloatingButtons(modifier: Modifier = Modifier) {
         FloatingActionButton(onClick = { }, containerColor = Color.Black.copy(alpha = 0.7f)) {
             Icon(Icons.Default.Refresh, contentDescription = "Refresh", tint = Color.White)
         }
-        FloatingActionButton(onClick = { }, containerColor = Color.Black.copy(alpha = 0.7f)) {
+        FloatingActionButton(onClick = onMapTypeChange, containerColor = Color.Black.copy(alpha = 0.7f)) {
             Icon(Icons.Default.Map, contentDescription = "Map Options", tint = Color.White)
         }
     }


### PR DESCRIPTION
This commit introduces the ability to switch between normal and satellite map views.

- A state variable for map properties has been added to `MainPage.kt`.
- The floating action button with the map icon now toggles the map type.
- The `GcsMap` composable has been updated to accept and apply the map properties.