### PR TITLE
feat: Add drone icon and path to map

### DIFF
--- a/app/src/main/java/com/example/aerogcsclone/Telemetry/SharedViewModel.kt
+++ b/app/src/main/java/com/example/aerogcsclone/Telemetry/SharedViewModel.kt
@@ -34,6 +34,10 @@ class SharedViewModel : ViewModel() {
     private val _uploadedWaypoints = MutableStateFlow<List<LatLng>>(emptyList())
     val uploadedWaypoints: StateFlow<List<LatLng>> = _uploadedWaypoints.asStateFlow()
 
+    // Store drone path for display on main screen
+    private val _dronePath = MutableStateFlow<List<LatLng>>(emptyList())
+    val dronePath: StateFlow<List<LatLng>> = _dronePath.asStateFlow()
+
     fun connect() {
         viewModelScope.launch {
             val portInt = port.toIntOrNull()
@@ -43,6 +47,12 @@ class SharedViewModel : ViewModel() {
                 newRepo.start()
                 newRepo.state.collect {
                     _telemetryState.value = it
+                    // Add the new location to the drone path
+                    it.latitude?.let { lat ->
+                        it.longitude?.let { lon ->
+                            _dronePath.value = _dronePath.value + LatLng(lat, lon)
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/aerogcsclone/uimain/GcsMap.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/GcsMap.kt
@@ -1,11 +1,19 @@
 package com.example.aerogcsclone.uimain
 
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import com.example.aerogcsclone.R
 import com.example.aerogcsclone.Telemetry.TelemetryState
 import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.BitmapDescriptor
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.*
 import com.google.maps.android.compose.MapType
@@ -14,12 +22,14 @@ import com.google.maps.android.compose.MapType
 fun GcsMap(
     telemetryState: TelemetryState,
     points: List<LatLng> = emptyList(),
+    dronePath: List<LatLng> = emptyList(),
     onMapClick: (LatLng) -> Unit = {},
     cameraPositionState: CameraPositionState? = null,
     mapType: MapType = MapType.NORMAL,
     autoCenter: Boolean = true // new flag to control automatic recentering
 ) {
     val cameraState = cameraPositionState ?: rememberCameraPositionState()
+    val context = LocalContext.current
 
     // Update camera when telemetry changes (live location) only if autoCenter is true
     val lat = telemetryState.latitude
@@ -37,7 +47,8 @@ fun GcsMap(
     ) {
         // Live drone marker
         if (lat != null && lon != null) {
-            Marker(state = MarkerState(position = LatLng(lat, lon)), title = "Drone Location")
+            val droneIcon = bitmapDescriptorFromVector(context, R.drawable.ic_drone)
+            Marker(state = MarkerState(position = LatLng(lat, lon)), title = "Drone Location", icon = droneIcon)
         }
 
         // User-drawn markers
@@ -48,6 +59,11 @@ fun GcsMap(
         // Draw polyline connecting waypoints
         if (points.size > 1) {
             Polyline(points = points, width = 4f)
+        }
+
+        // Draw drone path
+        if (dronePath.size > 1) {
+            Polyline(points = dronePath, width = 4f, color = Color.Red)
         }
 
         // If 4 or more points, draw a simple grid over bounding box
@@ -75,4 +91,14 @@ fun GcsMap(
             }
         }
     }
+}
+
+// Helper function to convert a vector drawable to a BitmapDescriptor
+fun bitmapDescriptorFromVector(context: Context, @DrawableRes vectorResId: Int): BitmapDescriptor? {
+    val vectorDrawable = ContextCompat.getDrawable(context, vectorResId)
+    vectorDrawable?.setBounds(0, 0, vectorDrawable.intrinsicWidth, vectorDrawable.intrinsicHeight)
+    val bitmap = Bitmap.createBitmap(vectorDrawable?.intrinsicWidth ?: 0, vectorDrawable?.intrinsicHeight ?: 0, Bitmap.Config.ARGB_8888)
+    val canvas = android.graphics.Canvas(bitmap)
+    vectorDrawable?.draw(canvas)
+    return BitmapDescriptorFactory.fromBitmap(bitmap)
 }

--- a/app/src/main/java/com/example/aerogcsclone/uimain/MainPage.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/MainPage.kt
@@ -26,6 +26,7 @@ fun MainPage(
     navController: NavHostController
 ) {
     val telemetryState by telemetryViewModel.telemetryState.collectAsState()
+    val dronePath by telemetryViewModel.dronePath.collectAsState()
     val context = LocalContext.current
 
     // 🔑 Map type state
@@ -50,7 +51,8 @@ fun MainPage(
             // ✅ Pass telemetryState and mapType to GcsMap
             GcsMap(
                 telemetryState = telemetryState,
-                mapType = mapType
+                mapType = mapType,
+                dronePath = dronePath
             )
 
             StatusPanel(

--- a/app/src/main/res/drawable/ic_drone.xml
+++ b/app/src/main/res/drawable/ic_drone.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M22,11H21L20,9H13.75L16,12.5H14L10.75,9H4C3.45,9 2,8.55 2,8C2,7.45 3.5,5.5 5.5,5.5C7.5,5.5 7.67,6.5 9,7H21A1,1 0 0,1 22,8V9L22,11M10.75,6.5L14,3H16L13.75,6.5H10.75M18,11V9.5H19.75L19,11H18M3,19A1,1 0 0,1 2,18A1,1 0 0,1 3,17A4,4 0 0,1 7,21A1,1 0 0,1 6,22A1,1 0 0,1 5,21A2,2 0 0,0 3,19M11,21A1,1 0 0,1 10,22A1,1 0 0,1 9,21A6,6 0 0,0 3,15A1,1 0 0,1 2,14A1,1 0 0,1 3,13A8,8 0 0,1 11,21Z"/>
+</vector>


### PR DESCRIPTION
This commit introduces two new features to the GCS map:
1.  The default marker for the drone's live location has been replaced with a custom drone icon.
2.  A red polyline is now drawn on the map to trace the drone's flight path in real-time.

A new vector drawable for the drone icon has been added. The `SharedViewModel` has been updated to store the drone's path, and the `GcsMap` composable has been modified to display the new icon and path.