### PR TITLE
Refactor ViewModel state handling for connection inputs

### DIFF
--- a/app/src/main/java/com/example/aerogcsclone/Telemetry/SharedViewModel.kt
+++ b/app/src/main/java/com/example/aerogcsclone/Telemetry/SharedViewModel.kt
@@ -2,6 +2,7 @@ package com.example.aerogcsclone.Telemetry
 
 import android.util.Log
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
@@ -15,8 +16,19 @@ import kotlinx.coroutines.delay
 
 class SharedViewModel : ViewModel() {
 
-    var ipAddress by mutableStateOf("10.0.2.2")
-    var port by mutableStateOf("5762")
+    private val _ipAddress = mutableStateOf("10.0.2.2")
+    val ipAddress: State<String> = _ipAddress
+
+    private val _port = mutableStateOf("5762")
+    val port: State<String> = _port
+
+    fun onIpAddressChange(newIp: String) {
+        _ipAddress.value = newIp
+    }
+
+    fun onPortChange(newPort: String) {
+        _port.value = newPort
+    }
 
     private var repo: MavlinkTelemetryRepository? = null
 
@@ -36,9 +48,9 @@ class SharedViewModel : ViewModel() {
 
     fun connect() {
         viewModelScope.launch {
-            val portInt = port.toIntOrNull()
+            val portInt = port.value.toIntOrNull()
             if (portInt != null) {
-                val newRepo = MavlinkTelemetryRepository(ipAddress, portInt)
+                val newRepo = MavlinkTelemetryRepository(ipAddress.value, portInt)
                 repo = newRepo
                 newRepo.start()
                 newRepo.state.collect {

--- a/app/src/main/java/com/example/aerogcsclone/uiconnection/ConnectionPage.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uiconnection/ConnectionPage.kt
@@ -51,8 +51,8 @@ fun ConnectionPage(navController: NavController, viewModel: SharedViewModel) {
             Spacer(modifier = Modifier.height(20.dp))
 
             OutlinedTextField(
-                value = viewModel.ipAddress,
-                onValueChange = { viewModel.ipAddress = it },
+                value = viewModel.ipAddress.value,
+                onValueChange = viewModel::onIpAddressChange,
                 label = { Text("IP Address", color = Color.White) },
                 modifier = Modifier.fillMaxWidth(),
                 textStyle = LocalTextStyle.current.copy(color = Color.White)
@@ -61,8 +61,8 @@ fun ConnectionPage(navController: NavController, viewModel: SharedViewModel) {
             Spacer(modifier = Modifier.height(12.dp))
 
             OutlinedTextField(
-                value = viewModel.port,
-                onValueChange = { viewModel.port = it },
+                value = viewModel.port.value,
+                onValueChange = viewModel::onPortChange,
                 label = { Text("Port", color = Color.White) },
                 modifier = Modifier.fillMaxWidth(),
                 textStyle = LocalTextStyle.current.copy(color = Color.White)


### PR DESCRIPTION
The `ipAddress` and `port` text fields on the connection screen were not updating because the state was not being properly handled.

This commit refactors the `SharedViewModel` to follow Jetpack Compose best practices for state management.

- The `ipAddress` and `port` properties in `SharedViewModel` are now private `MutableState` objects.
- They are exposed as public, immutable `State` objects.
- Public functions (`onIpAddressChange` and `onPortChange`) have been added to update the state, enforcing a unidirectional data flow.
- The `ConnectionPage` has been updated to use the new state objects and event handlers.

This ensures that user input in the text fields correctly updates the application's state.