### PR TITLE
Refactor state handling for connection inputs

### DIFF
--- a/app/src/main/java/com/example/aerogcsclone/Telemetry/SharedViewModel.kt
+++ b/app/src/main/java/com/example/aerogcsclone/Telemetry/SharedViewModel.kt
@@ -13,10 +13,23 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
 
+import androidx.compose.runtime.State
+
 class SharedViewModel : ViewModel() {
 
-    var ipAddress by mutableStateOf("10.0.2.2")
-    var port by mutableStateOf("5762")
+    private val _ipAddress = mutableStateOf("10.0.2.2")
+    val ipAddress: State<String> = _ipAddress
+
+    private val _port = mutableStateOf("5762")
+    val port: State<String> = _port
+
+    fun onIpAddressChange(newValue: String) {
+        _ipAddress.value = newValue
+    }
+
+    fun onPortChange(newValue: String) {
+        _port.value = newValue
+    }
 
     private var repo: MavlinkTelemetryRepository? = null
 
@@ -36,9 +49,9 @@ class SharedViewModel : ViewModel() {
 
     fun connect() {
         viewModelScope.launch {
-            val portInt = port.toIntOrNull()
+            val portInt = port.value.toIntOrNull()
             if (portInt != null) {
-                val newRepo = MavlinkTelemetryRepository(ipAddress, portInt)
+                val newRepo = MavlinkTelemetryRepository(ipAddress.value, portInt)
                 repo = newRepo
                 newRepo.start()
                 newRepo.state.collect {

--- a/app/src/main/java/com/example/aerogcsclone/uiconnection/ConnectionPage.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uiconnection/ConnectionPage.kt
@@ -50,9 +50,12 @@ fun ConnectionPage(navController: NavController, viewModel: SharedViewModel) {
 
             Spacer(modifier = Modifier.height(20.dp))
 
+            val ipAddress by viewModel.ipAddress
+            val port by viewModel.port
+
             OutlinedTextField(
-                value = viewModel.ipAddress,
-                onValueChange = { viewModel.ipAddress = it },
+                value = ipAddress,
+                onValueChange = { viewModel.onIpAddressChange(it) },
                 label = { Text("IP Address", color = Color.White) },
                 modifier = Modifier.fillMaxWidth(),
                 textStyle = LocalTextStyle.current.copy(color = Color.White)
@@ -61,8 +64,8 @@ fun ConnectionPage(navController: NavController, viewModel: SharedViewModel) {
             Spacer(modifier = Modifier.height(12.dp))
 
             OutlinedTextField(
-                value = viewModel.port,
-                onValueChange = { viewModel.port = it },
+                value = port,
+                onValueChange = { viewModel.onPortChange(it) },
                 label = { Text("Port", color = Color.White) },
                 modifier = Modifier.fillMaxWidth(),
                 textStyle = LocalTextStyle.current.copy(color = Color.White)


### PR DESCRIPTION
The `ipAddress` and `port` state variables in `SharedViewModel` were refactored to follow Unidirectional Data Flow (UDF) principles.

- Changed mutable `var` properties to private `MutableState` properties with public, immutable `State` properties.
- Introduced `onIpAddressChange` and `onPortChange` functions in the ViewModel to handle UI events.
- Updated `ConnectionPage` to use the new state and event handlers.

This change improves state management, making it more predictable and less prone to errors.