### PR TITLE
feat: Add polygon area to Grid Statistics

### DIFF
--- a/app/src/main/java/com/example/aerogcsclone/grid/GridGenerator.kt
+++ b/app/src/main/java/com/example/aerogcsclone/grid/GridGenerator.kt
@@ -25,7 +25,8 @@ class GridGenerator {
                 gridLines = emptyList(),
                 totalDistance = 0.0,
                 estimatedTime = 0.0,
-                numLines = 0
+                numLines = 0,
+                polygonArea = "0 ft²"
             )
         }
 
@@ -119,13 +120,15 @@ class GridGenerator {
         // Calculate total distance and time
         val totalDistance = calculateTotalDistance(waypoints)
         val estimatedTime = if (params.speed > 0) totalDistance / params.speed else 0.0
+        val polygonArea = GridUtils.calculateAndFormatPolygonArea(polygon)
 
         return GridSurveyResult(
             waypoints = waypoints,
             gridLines = gridLines,
             totalDistance = totalDistance,
             estimatedTime = estimatedTime,
-            numLines = gridLines.size
+            numLines = gridLines.size,
+            polygonArea = polygonArea
         )
     }
 

--- a/app/src/main/java/com/example/aerogcsclone/grid/GridWaypoint.kt
+++ b/app/src/main/java/com/example/aerogcsclone/grid/GridWaypoint.kt
@@ -33,5 +33,6 @@ data class GridSurveyResult(
     val gridLines: List<Pair<LatLng, LatLng>>, // For visualization
     val totalDistance: Double, // meters
     val estimatedTime: Double, // seconds
-    val numLines: Int
+    val numLines: Int,
+    val polygonArea: String
 )

--- a/app/src/main/java/com/example/aerogcsclone/uimain/PlanScreen.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/PlanScreen.kt
@@ -450,6 +450,7 @@ fun PlanScreen(
                                 Text("Lines: ${result.numLines}", color = Color.White, style = MaterialTheme.typography.bodySmall)
                                 Text("Distance: ${String.format(Locale.US, "%.1f", result.totalDistance / 1000)}km", color = Color.White, style = MaterialTheme.typography.bodySmall)
                                 Text("Time: ${String.format(Locale.US, "%.1f", result.estimatedTime / 60)}min", color = Color.White, style = MaterialTheme.typography.bodySmall)
+                                Text("Area: ${result.polygonArea}", color = Color.White, style = MaterialTheme.typography.bodySmall)
                             }
                         }
 


### PR DESCRIPTION
This commit introduces the following changes:

- Adds a `polygonArea` field to the `GridSurveyResult` data class to store the formatted area string.
- Implements a new helper function, `calculateAndFormatPolygonArea`, in `GridUtils.kt`. This function uses `SphericalUtil.computeArea` for accurate area calculation and formats the result into square feet, acres, or square miles based on specified thresholds.
- Updates the existing `calculatePolygonArea` function to use the more accurate `SphericalUtil.computeArea` method.
- Integrates the area calculation into the `GridGenerator`'s `generateGridSurvey` function, populating the new `polygonArea` field in the result.
- Updates the `PlanScreen` composable to display the calculated polygon area within the "Grid Statistics" panel.