### PR TITLE
feat: Add SelectFlyingMethodScreen

### DIFF
--- a/app/src/main/java/com/example/aerogcsclone/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/example/aerogcsclone/navigation/AppNavGraph.kt
@@ -17,6 +17,7 @@ import com.example.aerogcsclone.authentication.SignupPage
 import com.example.aerogcsclone.authentication.WelcomeScreen
 import com.example.aerogcsclone.integration.TlogIntegration
 import com.example.aerogcsclone.uiconnection.ConnectionPage
+import com.example.aerogcsclone.uiflyingmethod.SelectFlyingMethodScreen
 import com.example.aerogcsclone.uimain.MainPage
 import com.example.aerogcsclone.uimain.PlanScreen
 import com.example.aerogcsclone.uimain.TopNavBar
@@ -34,6 +35,7 @@ sealed class Screen(val route: String) {
     object Plan : Screen("plan")
     object PlotTemplates : Screen("plot_templates")
     object Logs : Screen("logs")
+    object SelectFlyingMethod : Screen("select_flying_method")
 }
 
 @Composable
@@ -75,6 +77,9 @@ fun AppNavGraph(navController: NavHostController) {
                 navController = navController,
                 viewModel = sharedViewModel
             )
+        }
+        composable(Screen.SelectFlyingMethod.route) {
+            SelectFlyingMethodScreen(navController = navController)
         }
         composable(Screen.Main.route) {
             MainPage(

--- a/app/src/main/java/com/example/aerogcsclone/uiconnection/ConnectionPage.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uiconnection/ConnectionPage.kt
@@ -30,7 +30,7 @@ fun ConnectionPage(navController: NavController, viewModel: SharedViewModel) {
             if (isConnected) {
                 isConnecting = false
                 connectionJob?.cancel()
-                navController.navigate(Screen.Main.route) {
+                navController.navigate(Screen.SelectFlyingMethod.route) {
                     popUpTo(Screen.Connection.route) { inclusive = true }
                 }
             }

--- a/app/src/main/java/com/example/aerogcsclone/uiflyingmethod/SelectFlyingMethodScreen.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uiflyingmethod/SelectFlyingMethodScreen.kt
@@ -1,0 +1,92 @@
+package com.example.aerogcsclone.uiflyingmethod
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.example.aerogcsclone.R
+import com.example.aerogcsclone.navigation.Screen
+
+@Composable
+fun SelectFlyingMethodScreen(navController: NavController) {
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = Color.Black
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "Select Flying Method",
+                color = Color.White,
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 48.dp)
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                FlyingMethodCard(
+                    icon = { Icon(Icons.Default.PlayArrow, contentDescription = "Automatic", tint = Color.White, modifier = Modifier.size(64.dp)) },
+                    label = "Automatic",
+                    onClick = { navController.navigate(Screen.Main.route) }
+                )
+                FlyingMethodCard(
+                    icon = { Icon(painter = painterResource(id = R.drawable.ic_drone), contentDescription = "Manual", tint = Color.White, modifier = Modifier.size(64.dp)) },
+                    label = "Manual",
+                    onClick = { navController.navigate(Screen.Main.route) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun FlyingMethodCard(
+    icon: @Composable () -> Unit,
+    label: String,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .size(150.dp)
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.DarkGray)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            icon()
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = label,
+                color = Color.White,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces the `SelectFlyingMethodScreen` as a new step in the navigation flow, appearing after the connection screen and before the main page.

The screen is built with Jetpack Compose and Material 3 components, featuring a dark theme with two selectable cards for "Automatic" and "Manual" flight modes. Both cards navigate to the `HomeScreenMainPage`.

The navigation graph in `AppNavGraph.kt` has been updated to include the new screen, and the `ConnectionPage.kt` is modified to navigate to `SelectFlyingMethodScreen` upon a successful connection, establishing the following flow: Welcome > Login > Connection > SelectFlyingMethod > Main