### PR TITLE
feat: Implement Bluetooth MAVLink connectivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,27 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
+    <!-- Request legacy Bluetooth permissions on older devices. -->
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+
+    <!--
+ Needed for Bluetooth scanning on Android 12+
+        https://developer.android.com/guide/topics/connectivity/bluetooth/permissions
+    -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+
+    <!--
+ Needed for connecting to paired Bluetooth devices on Android 12+
+         https://developer.android.com/guide/topics/connectivity/bluetooth/permissions
+    -->
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+    <!-- Declare that the app uses Bluetooth -->
+    <uses-feature android:name="android.hardware.bluetooth" android:required="true"/>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/aerogcsclone/MainActivity.kt
+++ b/app/src/main/java/com/example/aerogcsclone/MainActivity.kt
@@ -33,14 +33,28 @@ private val DarkColorScheme = darkColorScheme(
 
 class MainActivity : ComponentActivity() {
 
-    private val hasPermission = mutableStateOf(false)
+    private val hasRequiredPermissions = mutableStateOf(false)
 
-    private val requestLocation = registerForActivityResult(
+    private val requestPermissionsLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
     ) { grants ->
-        val fine = grants[Manifest.permission.ACCESS_FINE_LOCATION] == true
-        val coarse = grants[Manifest.permission.ACCESS_COARSE_LOCATION] == true
-        hasPermission.value = fine || coarse
+        val fineLocation = grants.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false)
+        val coarseLocation = grants.getOrDefault(Manifest.permission.ACCESS_COARSE_LOCATION, false)
+
+        val bluetoothScanGranted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            grants.getOrDefault(Manifest.permission.BLUETOOTH_SCAN, false)
+        } else {
+            true // Not required for older APIs
+        }
+
+        val bluetoothConnectGranted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            grants.getOrDefault(Manifest.permission.BLUETOOTH_CONNECT, false)
+        } else {
+            true // Not required for older APIs
+        }
+
+        // For the app to function, we need location and the relevant BT permissions.
+        hasRequiredPermissions.value = (fineLocation || coarseLocation) && bluetoothScanGranted && bluetoothConnectGranted
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -69,7 +83,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
-        askLocationPermissions()
+        askForPermissions()
     }
 
     override fun onDestroy() {
@@ -78,12 +92,17 @@ class MainActivity : ComponentActivity() {
         TlogIntegration.destroy()
     }
 
-    private fun askLocationPermissions() {
-        requestLocation.launch(
-            arrayOf(
-                Manifest.permission.ACCESS_FINE_LOCATION,
-                Manifest.permission.ACCESS_COARSE_LOCATION
-            )
+    private fun askForPermissions() {
+        val permissionsToRequest = mutableListOf(
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION
         )
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            permissionsToRequest.add(Manifest.permission.BLUETOOTH_SCAN)
+            permissionsToRequest.add(Manifest.permission.BLUETOOTH_CONNECT)
+        }
+
+        requestPermissionsLauncher.launch(permissionsToRequest.toTypedArray())
     }
 }

--- a/app/src/main/java/com/example/aerogcsclone/Telemetry/TelemetryRepository.kt
+++ b/app/src/main/java/com/example/aerogcsclone/Telemetry/TelemetryRepository.kt
@@ -9,6 +9,7 @@ import com.divpundir.mavlink.connection.StreamState
 import com.divpundir.mavlink.connection.tcp.TcpClientMavConnection
 import com.divpundir.mavlink.definitions.common.*
 import com.divpundir.mavlink.definitions.minimal.*
+import com.example.aerogcsclone.Telemetry.connections.MavConnectionProvider
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
@@ -26,8 +27,7 @@ object MavMode {
 }
 
 class MavlinkTelemetryRepository(
-    private val host: String,
-    private val port: Int
+    private val provider: MavConnectionProvider
 ) {
     private val gcsSystemId: UByte = 255u
     private val gcsComponentId: UByte = 1u
@@ -42,7 +42,7 @@ class MavlinkTelemetryRepository(
     val lastFailure: StateFlow<Throwable?> = _lastFailure.asStateFlow()
 
     // Connection
-    private val connection = TcpClientMavConnection(host, port, CommonDialect).asCoroutine()
+    private val connection = provider.createConnection()
 
     // MAVLink command value for MISSION_CLEAR_ALL
     private val MISSION_CLEAR_ALL_CMD: UInt = 45u

--- a/app/src/main/java/com/example/aerogcsclone/Telemetry/connections/BluetoothConnectionProvider.kt
+++ b/app/src/main/java/com/example/aerogcsclone/Telemetry/connections/BluetoothConnectionProvider.kt
@@ -1,0 +1,15 @@
+package com.example.aerogcsclone.Telemetry.connections
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import com.divpundir.mavlink.adapters.coroutines.CoroutinesMavConnection
+import com.divpundir.mavlink.adapters.coroutines.asCoroutine
+
+@SuppressLint("MissingPermission")
+class BluetoothConnectionProvider(
+    private val device: BluetoothDevice
+) : MavConnectionProvider {
+    override fun createConnection(): CoroutinesMavConnection {
+        return BluetoothMavConnection(device).asCoroutine()
+    }
+}

--- a/app/src/main/java/com/example/aerogcsclone/Telemetry/connections/BluetoothMavConnection.kt
+++ b/app/src/main/java/com/example/aerogcsclone/Telemetry/connections/BluetoothMavConnection.kt
@@ -1,0 +1,85 @@
+package com.example.aerogcsclone.Telemetry.connections
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothSocket
+import com.divpundir.mavlink.connection.MavConnection
+import com.divpundir.mavlink.connection.StreamState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.UUID
+
+@SuppressLint("MissingPermission") // Permissions are checked before this class is instantiated
+class BluetoothMavConnection(
+    private val bluetoothDevice: BluetoothDevice
+) : MavConnection {
+
+    companion object {
+        // The standard UUID for the Serial Port Profile (SPP)
+        private val SPP_UUID: UUID = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB")
+    }
+
+    private var socket: BluetoothSocket? = null
+    private var inputStream: InputStream? = null
+    private var outputStream: OutputStream? = null
+
+    private val _streamState = MutableStateFlow<StreamState>(StreamState.Inactive)
+    override val streamState = _streamState.asStateFlow()
+
+    @Throws(IOException::class)
+    override suspend fun connect() {
+        withContext(Dispatchers.IO) {
+            try {
+                // Create an RFCOMM socket to connect to the SPP service
+                socket = bluetoothDevice.createRfcommSocketToServiceRecord(SPP_UUID)
+                socket?.connect() // This is a blocking call
+
+                // Get the input and output streams
+                inputStream = socket?.inputStream
+                outputStream = socket?.outputStream
+
+                _streamState.value = StreamState.Active
+            } catch (e: IOException) {
+                // Clean up and re-throw the exception to be handled by the caller
+                close()
+                throw e
+            }
+        }
+    }
+
+    @Throws(IOException::class)
+    override suspend fun close() {
+        withContext(Dispatchers.IO) {
+            _streamState.value = StreamState.Inactive
+            try {
+                inputStream?.close()
+            } catch (e: IOException) { /* Ignore */ }
+            try {
+                outputStream?.close()
+            } catch (e: IOException) { /* Ignore */ }
+            try {
+                socket?.close()
+            } catch (e: IOException) { /* Ignore */ }
+            socket = null
+            inputStream = null
+            outputStream = null
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun read(): Int {
+        val stream = inputStream?: throw IOException("Bluetooth connection is not active.")
+        return stream.read() // This is a blocking call
+    }
+
+    @Throws(IOException::class)
+    override fun write(data: ByteArray) {
+        val stream = outputStream?: throw IOException("Bluetooth connection is not active.")
+        stream.write(data) // This can be a blocking call
+    }
+}

--- a/app/src/main/java/com/example/aerogcsclone/Telemetry/connections/MavConnectionProvider.kt
+++ b/app/src/main/java/com/example/aerogcsclone/Telemetry/connections/MavConnectionProvider.kt
@@ -1,0 +1,11 @@
+package com.example.aerogcsclone.Telemetry.connections
+
+import com.divpundir.mavlink.adapters.coroutines.CoroutinesMavConnection
+
+/**
+ * An interface for providing a MAVLink connection.
+ * This abstraction allows the repository to be transport-agnostic.
+ */
+interface MavConnectionProvider {
+    fun createConnection(): CoroutinesMavConnection
+}

--- a/app/src/main/java/com/example/aerogcsclone/Telemetry/connections/TcpConnectionProvider.kt
+++ b/app/src/main/java/com/example/aerogcsclone/Telemetry/connections/TcpConnectionProvider.kt
@@ -1,0 +1,19 @@
+package com.example.aerogcsclone.Telemetry.connections
+
+import com.divpundir.mavlink.adapters.coroutines.CoroutinesMavConnection
+import com.divpundir.mavlink.adapters.coroutines.asCoroutine
+import com.divpundir.mavlink.connection.tcp.TcpClientMavConnection
+import com.divpundir.mavlink.definitions.common.CommonDialect
+
+class TcpConnectionProvider(
+    private val host: String,
+    private val port: Int
+) : MavConnectionProvider {
+    override fun createConnection(): CoroutinesMavConnection {
+        return TcpClientMavConnection(
+            host,
+            port,
+            CommonDialect
+        ).asCoroutine()
+    }
+}

--- a/app/src/main/java/com/example/aerogcsclone/uiconnection/ConnectionPage.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uiconnection/ConnectionPage.kt
@@ -1,7 +1,14 @@
 package com.example.aerogcsclone.uiconnection
 
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.content.Context
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -10,6 +17,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.example.aerogcsclone.Telemetry.ConnectionType
+import com.example.aerogcsclone.Telemetry.PairedDevice
 import com.example.aerogcsclone.Telemetry.SharedViewModel
 import com.example.aerogcsclone.navigation.Screen
 import kotlinx.coroutines.Job
@@ -17,6 +26,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
+@SuppressLint("MissingPermission")
 @Composable
 fun ConnectionPage(navController: NavController, viewModel: SharedViewModel) {
     var isConnecting by remember { mutableStateOf(false) }
@@ -24,7 +34,24 @@ fun ConnectionPage(navController: NavController, viewModel: SharedViewModel) {
     val coroutineScope = rememberCoroutineScope()
     var connectionJob by remember { mutableStateOf<Job?>(null) }
     var showPopup by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    val connectionType by viewModel.connectionType
 
+    // When the page is shown, get the paired Bluetooth devices
+    LaunchedEffect(Unit) {
+        val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager?
+        val bluetoothAdapter: BluetoothAdapter? = bluetoothManager?.adapter
+        if (bluetoothAdapter != null) {
+            try {
+                val pairedBtDevices = bluetoothAdapter.bondedDevices
+                viewModel.setPairedDevices(pairedBtDevices)
+            } catch (se: SecurityException) {
+                errorMessage = "Bluetooth permission missing."
+            }
+        }
+    }
+
+    // React to connection state changes from the ViewModel
     LaunchedEffect(viewModel) {
         viewModel.isConnected.collectLatest { isConnected ->
             if (isConnected) {
@@ -37,27 +64,22 @@ fun ConnectionPage(navController: NavController, viewModel: SharedViewModel) {
         }
     }
 
-    fun startConnection(autoRetry: Boolean = false) {
+    fun startConnection() {
         isConnecting = true
         errorMessage = ""
-        connectionJob?.cancel()
+        connectionJob?.cancel() // Cancel any previous job
         connectionJob = coroutineScope.launch {
-            var attempts = 0
-            val maxAttempts = if (autoRetry) 3 else 1
-            while (attempts < maxAttempts && !viewModel.isConnected.value) {
-                try {
-                    viewModel.connect()
-                } catch (e: Exception) {
-                    errorMessage = e.message ?: "Connection failed"
-                }
-                attempts++
-                if (!viewModel.isConnected.value && autoRetry && attempts < maxAttempts) {
-                    delay(5000)
-                }
-            }
-            if (!viewModel.isConnected.value) {
+            viewModel.connect() // Ask the ViewModel to connect
+
+            // Set a timeout for the connection attempt
+            delay(10000) // 10-second timeout
+
+            // If we are still in a 'connecting' state after the timeout, it failed.
+            if (isConnecting) {
                 isConnecting = false
+                errorMessage = "Connection timed out. Please check your settings and try again."
                 showPopup = true
+                viewModel.cancelConnection() // Clean up the failed attempt
             }
         }
     }
@@ -69,6 +91,11 @@ fun ConnectionPage(navController: NavController, viewModel: SharedViewModel) {
         coroutineScope.launch {
             viewModel.cancelConnection()
         }
+    }
+
+    val isConnectEnabled = !isConnecting && when (connectionType) {
+        ConnectionType.TCP -> viewModel.ipAddress.value.isNotBlank() && viewModel.port.value.isNotBlank()
+        ConnectionType.BLUETOOTH -> viewModel.selectedDevice.value != null
     }
 
     Box(
@@ -90,73 +117,124 @@ fun ConnectionPage(navController: NavController, viewModel: SharedViewModel) {
 
             Spacer(modifier = Modifier.height(20.dp))
 
-            val ipAddress by viewModel.ipAddress
-            val port by viewModel.port
+            val tabs = listOf("TCP/IP", "Bluetooth")
+            TabRow(selectedTabIndex = connectionType.ordinal, containerColor = Color(0xFF333330)) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = connectionType.ordinal == index,
+                        onClick = { viewModel.onConnectionTypeChange(ConnectionType.values()[index]) },
+                        text = { Text(title, color = Color.White) }
+                    )
+                }
+            }
 
-            OutlinedTextField(
-                value = ipAddress,
-                onValueChange = { viewModel.onIpAddressChange(it) },
-                label = { Text("IP Address", color = Color.White) },
-                modifier = Modifier.fillMaxWidth(),
-                textStyle = LocalTextStyle.current.copy(color = Color.White)
-            )
+            Spacer(modifier = Modifier.height(20.dp))
 
-            Spacer(modifier = Modifier.height(12.dp))
-
-            OutlinedTextField(
-                value = port,
-                onValueChange = { viewModel.onPortChange(it) },
-                label = { Text("Port", color = Color.White) },
-                modifier = Modifier.fillMaxWidth(),
-                textStyle = LocalTextStyle.current.copy(color = Color.White)
-            )
+            when (connectionType) {
+                ConnectionType.TCP -> TcpConnectionContent(viewModel)
+                ConnectionType.BLUETOOTH -> BluetoothConnectionContent(viewModel)
+            }
 
             Spacer(modifier = Modifier.height(20.dp))
 
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
                 Button(
-                    onClick = { startConnection(autoRetry = true) },
+                    onClick = { startConnection() },
                     modifier = Modifier.weight(1f),
-                    enabled = !isConnecting
+                    enabled = isConnectEnabled
                 ) {
                     Text(if (isConnecting) "Connecting..." else "Connect")
                 }
                 Spacer(modifier = Modifier.width(12.dp))
                 Button(
-                    onClick = { startConnection(autoRetry = false) },
+                    onClick = { cancelConnection() },
                     modifier = Modifier.weight(1f),
-                    enabled = !isConnecting
+                    enabled = isConnecting
                 ) {
-                    Text("Retry")
+                    Text("Cancel")
                 }
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
-
-            Button(
-                onClick = { cancelConnection() },
-                modifier = Modifier.fillMaxWidth(),
-                enabled = isConnecting
-            ) {
-                Text("Cancel")
-            }
-
-            if (errorMessage.isNotEmpty()) {
+            if (errorMessage.isNotEmpty() && !showPopup) {
                 Spacer(modifier = Modifier.height(10.dp))
                 Text(errorMessage, color = MaterialTheme.colorScheme.error)
             }
         }
+
         if (showPopup) {
             AlertDialog(
                 onDismissRequest = { showPopup = false },
                 title = { Text("Connection Failed") },
-                text = { Text("Unable to connect to the drone after multiple attempts.") },
+                text = { Text(errorMessage) },
                 confirmButton = {
                     Button(onClick = { showPopup = false }) {
                         Text("OK")
                     }
                 }
             )
+        }
+    }
+}
+
+@Composable
+fun TcpConnectionContent(viewModel: SharedViewModel) {
+    val ipAddress by viewModel.ipAddress
+    val port by viewModel.port
+
+    OutlinedTextField(
+        value = ipAddress,
+        onValueChange = { viewModel.onIpAddressChange(it) },
+        label = { Text("IP Address", color = Color.White) },
+        modifier = Modifier.fillMaxWidth(),
+        textStyle = LocalTextStyle.current.copy(color = Color.White)
+    )
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    OutlinedTextField(
+        value = port,
+        onValueChange = { viewModel.onPortChange(it) },
+        label = { Text("Port", color = Color.White) },
+        modifier = Modifier.fillMaxWidth(),
+        textStyle = LocalTextStyle.current.copy(color = Color.White)
+    )
+}
+
+@Composable
+fun BluetoothConnectionContent(viewModel: SharedViewModel) {
+    val pairedDevices by viewModel.pairedDevices.collectAsState()
+    val selectedDevice by viewModel.selectedDevice
+
+    if (pairedDevices.isEmpty()) {
+        Box(modifier = Modifier.fillMaxWidth().height(150.dp), contentAlignment = Alignment.Center) {
+            Text("No paired Bluetooth devices found.", color = Color.White)
+        }
+    } else {
+        LazyColumn(modifier = Modifier.fillMaxWidth().height(150.dp)) {
+            items(pairedDevices) { device ->
+                DeviceRow(
+                    device = device,
+                    isSelected = device.address == selectedDevice?.address,
+                    onClick = { viewModel.onDeviceSelected(device) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun DeviceRow(device: PairedDevice, isSelected: Boolean, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .background(if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.5f) else Color.Transparent)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column {
+            Text(device.name, color = Color.White, style = MaterialTheme.typography.bodyLarge)
+            Text(device.address, color = Color.Gray, style = MaterialTheme.typography.bodyMedium)
         }
     }
 }


### PR DESCRIPTION
This commit introduces Bluetooth as a new MAVLink connection transport, alongside the existing TCP/IP method.

The implementation follows the Strategy design pattern to ensure the connection logic is transport-agnostic:
- A `MavConnectionProvider` interface has been created to abstract the connection creation.
- `TcpConnectionProvider` and `BluetoothConnectionProvider` are the concrete implementations for each transport type.
- `MavlinkTelemetryRepository` is now decoupled from a specific connection implementation and depends on the `MavConnectionProvider` interface.

The UI on the `ConnectionPage` has been redesigned with a `TabRow` to allow users to select between TCP and Bluetooth. The UI dynamically updates to show the relevant connection controls, including a list of paired Bluetooth devices.

The following changes have been made to support this feature:
- Added necessary Bluetooth permissions to `AndroidManifest.xml`.
- Implemented runtime permission requests for Bluetooth in `MainActivity`.
- Updated `SharedViewModel` to manage the state for both connection types.