### PR TITLE
feat: Implement IMU Calibration Feature

### DIFF
--- a/app/src/main/java/com/example/aerogcsclone/calibration/CalibrationService.kt
+++ b/app/src/main/java/com/example/aerogcsclone/calibration/CalibrationService.kt
@@ -1,0 +1,12 @@
+package com.example.aerogcsclone.calibration
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface CalibrationService {
+    val calibrationState: StateFlow<CalibrationState>
+
+    suspend fun startImuCalibration()
+    suspend fun advanceImuCalibrationStep(position: ImuPosition)
+    suspend fun startCompassCalibration()
+    suspend fun cancelCalibration()
+}

--- a/app/src/main/java/com/example/aerogcsclone/calibration/CalibrationState.kt
+++ b/app/src/main/java/com/example/aerogcsclone/calibration/CalibrationState.kt
@@ -1,0 +1,27 @@
+package com.example.aerogcsclone.calibration
+
+import kotlinx.coroutines.flow.StateFlow
+
+enum class ImuPosition {
+    LEVEL,
+    RIGHT_SIDE,
+    LEFT_SIDE,
+    NOSE_DOWN,
+    NOSE_UP,
+    BACK
+}
+
+sealed class CalibrationState {
+    object Idle : CalibrationState()
+    data class InProgress(
+        val message: String,
+        val progress: Float? = null,
+        val multiProgress: Map<Int, Float>? = null
+    ) : CalibrationState()
+    data class AwaitingUserInput(
+        val instruction: String,
+        val visualHint: ImuPosition
+    ) : CalibrationState()
+    data class Success(val summary: String) : CalibrationState()
+    data class Error(val message: String) : CalibrationState()
+}

--- a/app/src/main/java/com/example/aerogcsclone/calibration/ImuCalibrationScreen.kt
+++ b/app/src/main/java/com/example/aerogcsclone/calibration/ImuCalibrationScreen.kt
@@ -1,0 +1,84 @@
+package com.example.aerogcsclone.calibration
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun ImuCalibrationScreen(
+    viewModel: ImuCalibrationViewModel = hiltViewModel(),
+    onComplete: () -> Unit,
+    onCancel: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        when (val state = uiState) {
+            is CalibrationState.Idle -> {
+                Text("IMU Calibration")
+                Spacer(modifier = Modifier.height(16.dp))
+                Button(onClick = { viewModel.onStartClicked() }) {
+                    Text("Start Calibration")
+                }
+            }
+            is CalibrationState.AwaitingUserInput -> {
+                Text(text = state.instruction, style = MaterialTheme.typography.headlineSmall)
+                Spacer(modifier = Modifier.height(32.dp))
+                ImuPositionVisual(position = state.visualHint)
+                Spacer(modifier = Modifier.height(32.dp))
+                Row {
+                    Button(onClick = {
+                        viewModel.onCancelClicked()
+                        onCancel()
+                    }) {
+                        Text("Cancel")
+                    }
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Button(onClick = { viewModel.onPositionAcknowledged() }) {
+                        Text("Next")
+                    }
+                }
+            }
+            is CalibrationState.InProgress -> {
+                CircularProgressIndicator()
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(state.message)
+            }
+            is CalibrationState.Success -> {
+                Text(state.summary)
+                Spacer(modifier = Modifier.height(16.dp))
+                Button(onClick = onComplete) {
+                    Text("Done")
+                }
+            }
+            is CalibrationState.Error -> {
+                Text(state.message)
+                Spacer(modifier = Modifier.height(16.dp))
+                Row {
+                    Button(onClick = {
+                        viewModel.onCancelClicked()
+                        onCancel()
+                    }) {
+                        Text("Cancel")
+                    }
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Button(onClick = { viewModel.onStartClicked() }) {
+                        Text("Retry")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/aerogcsclone/calibration/ImuCalibrationViewModel.kt
+++ b/app/src/main/java/com/example/aerogcsclone/calibration/ImuCalibrationViewModel.kt
@@ -1,0 +1,48 @@
+package com.example.aerogcsclone.calibration
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ImuCalibrationViewModel @Inject constructor(
+    private val calibrationService: CalibrationService
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<CalibrationState>(CalibrationState.Idle)
+    val uiState: StateFlow<CalibrationState> = _uiState.asStateFlow()
+
+    init {
+        calibrationService.calibrationState
+            .onEach { _uiState.value = it }
+            .launchIn(viewModelScope)
+    }
+
+    fun onStartClicked() {
+        viewModelScope.launch {
+            calibrationService.startImuCalibration()
+        }
+    }
+
+    fun onPositionAcknowledged() {
+        viewModelScope.launch {
+            val currentState = _uiState.value
+            if (currentState is CalibrationState.AwaitingUserInput) {
+                calibrationService.advanceImuCalibrationStep(currentState.visualHint)
+            }
+        }
+    }
+
+    fun onCancelClicked() {
+        viewModelScope.launch {
+            calibrationService.cancelCalibration()
+        }
+    }
+}

--- a/app/src/main/java/com/example/aerogcsclone/calibration/ImuPosition.kt
+++ b/app/src/main/java/com/example/aerogcsclone/calibration/ImuPosition.kt
@@ -1,0 +1,24 @@
+package com.example.aerogcsclone.calibration
+
+enum class ImuPosition(val mavlinkValue: UInt) {
+    LEVEL(1u),
+    ON_RIGHT_SIDE(3u),
+    ON_LEFT_SIDE(2u),
+    NOSE_DOWN(4u),
+    NOSE_UP(5u),
+    ON_ITS_BACK(6u);
+
+    companion object {
+        fun fromInstruction(instruction: String): ImuPosition? {
+            return when {
+                "level" in instruction.lowercase() -> LEVEL
+                "left" in instruction.lowercase() -> ON_LEFT_SIDE
+                "right" in instruction.lowercase() -> ON_RIGHT_SIDE
+                "nose down" in instruction.lowercase() -> NOSE_DOWN
+                "nose up" in instruction.lowercase() -> NOSE_UP
+                "back" in instruction.lowercase() -> ON_ITS_BACK
+                else -> null
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/aerogcsclone/calibration/ImuPositionVisual.kt
+++ b/app/src/main/java/com/example/aerogcsclone/calibration/ImuPositionVisual.kt
@@ -1,0 +1,19 @@
+package com.example.aerogcsclone.calibration
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ImuPositionVisual(position: ImuPosition) {
+    Box(
+        modifier = Modifier.size(150.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Placeholder for ${position.name}")
+    }
+}

--- a/app/src/main/java/com/example/aerogcsclone/calibration/MavlinkCalibrationService.kt
+++ b/app/src/main/java/com/example/aerogcsclone/calibration/MavlinkCalibrationService.kt
@@ -1,0 +1,94 @@
+package com.example.aerogcsclone.calibration
+
+import android.util.Log
+import com.divpundir.mavlink.definitions.ardupilotmega.AccelcalVehiclePos
+import com.divpundir.mavlink.definitions.common.MavCmd
+import com.divpundir.mavlink.definitions.common.Statustext
+import com.example.aerogcsclone.telemetry.MavlinkTelemetryRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MavlinkCalibrationService @Inject constructor(
+    private val telemetryRepository: MavlinkTelemetryRepository,
+    private val externalScope: CoroutineScope
+) : CalibrationService {
+
+    private val _calibrationState = MutableStateFlow<CalibrationState>(CalibrationState.Idle)
+    override val calibrationState: StateFlow<CalibrationState> = _calibrationState.asStateFlow()
+
+    private var calibrationJob: Job? = null
+
+    override suspend fun startImuCalibration() {
+        cancelOngoingCalibration()
+        _calibrationState.value = CalibrationState.InProgress("Starting IMU calibration...")
+
+        calibrationJob = externalScope.launch {
+            telemetryRepository.mavFrame
+                .filterIsInstance<Statustext>()
+                .onCompletion {
+                    if (_calibrationState.value is CalibrationState.InProgress) {
+                        _calibrationState.value = CalibrationState.Error("Calibration stopped unexpectedly.")
+                    }
+                }
+                .collect { statustext ->
+                    handleStatusText(statustext)
+                }
+        }
+
+        telemetryRepository.sendCommandLong(
+            MavCmd.PREFLIGHT_CALIBRATION,
+            param5 = 1f // 1.0f for accelerometer
+        )
+    }
+
+    private fun handleStatusText(statustext: Statustext) {
+        val message = statustext.text.toString()
+        Log.d("CalibrationService", "STATUSTEXT: $message")
+
+        when {
+            message.contains("Place vehicle") -> {
+                val position = ImuPosition.fromInstruction(message)
+                if (position != null) {
+                    _calibrationState.value = CalibrationState.AwaitingUserInput(message, position)
+                }
+            }
+            message.contains("Calibration successful") -> {
+                _calibrationState.value = CalibrationState.Success("IMU Calibration Successful!")
+                cancelOngoingCalibration()
+            }
+            message.contains("Calibration FAILED") -> {
+                _calibrationState.value = CalibrationState.Error("IMU Calibration Failed.")
+                cancelOngoingCalibration()
+            }
+        }
+    }
+
+    override suspend fun advanceImuCalibrationStep(position: ImuPosition) {
+        val accelcalVehiclePos = AccelcalVehiclePos.values().first { it.value == position.mavlinkValue }
+        _calibrationState.value = CalibrationState.InProgress("Acknowledged ${position.name}. Capturing data...")
+        telemetryRepository.sendCommandLong(
+            MavCmd.ACCELCAL_VEHICLE_POS,
+            param1 = accelcalVehiclePos.value.toFloat()
+        )
+    }
+
+    override suspend fun startCompassCalibration() {
+        _calibrationState.value = CalibrationState.Error("Compass calibration not implemented yet.")
+    }
+
+    override suspend fun cancelCalibration() {
+        cancelOngoingCalibration()
+        telemetryRepository.sendCommandLong(MavCmd.PREFLIGHT_CALIBRATION) // All params 0 cancels
+        _calibrationState.value = CalibrationState.Idle
+    }
+
+    private fun cancelOngoingCalibration() {
+        calibrationJob?.cancel()
+        calibrationJob = null
+    }
+}

--- a/app/src/main/java/com/example/aerogcsclone/di/CalibrationModule.kt
+++ b/app/src/main/java/com/example/aerogcsclone/di/CalibrationModule.kt
@@ -1,0 +1,31 @@
+package com.example.aerogcsclone.di
+
+import com.example.aerogcsclone.calibration.CalibrationService
+import com.example.aerogcsclone.calibration.MavlinkCalibrationService
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CalibrationModule {
+
+    @Binds
+    abstract fun bindCalibrationService(
+        mavlinkCalibrationService: MavlinkCalibrationService
+    ): CalibrationService
+
+    companion object {
+        @Provides
+        @Singleton
+        fun provideCoroutineScope(): CoroutineScope {
+            return CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        }
+    }
+}

--- a/app/src/main/java/com/example/aerogcsclone/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/example/aerogcsclone/navigation/AppNavGraph.kt
@@ -39,6 +39,7 @@ sealed class Screen(val route: String) {
     object SelectMethod : Screen("select_method")
     object Settings : Screen("settings")
     object Calibrations : Screen("calibrations")
+    object ImuCalibration : Screen("imu_calibration")
 }
 
 @Composable
@@ -118,7 +119,16 @@ fun AppNavGraph(navController: NavHostController) {
             com.example.aerogcsclone.uimain.SettingsScreen(navController)
         }
         composable(Screen.Calibrations.route) {
-            com.example.aerogcsclone.uimain.CalibrationsScreen(viewModel = sharedViewModel)
+            com.example.aerogcsclone.uimain.CalibrationsScreen(
+                viewModel = sharedViewModel,
+                navController = navController
+            )
+        }
+        composable(Screen.ImuCalibration.route) {
+            com.example.aerogcsclone.calibration.ImuCalibrationScreen(
+                onComplete = { navController.popBackStack() },
+                onCancel = { navController.popBackStack() }
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/aerogcsclone/telemetry/TelemetryRepository.kt
+++ b/app/src/main/java/com/example/aerogcsclone/telemetry/TelemetryRepository.kt
@@ -52,7 +52,6 @@ class MavlinkTelemetryRepository(
     // Connection
     val connection = provider.createConnection()
     lateinit var mavFrame: Flow<MavFrame<out MavMessage<*>>>
-        private set
 
     // MAVLink command value for MISSION_CLEAR_ALL
     private val MISSION_CLEAR_ALL_CMD: UInt = 45u

--- a/app/src/main/java/com/example/aerogcsclone/uimain/CalibrationsScreen.kt
+++ b/app/src/main/java/com/example/aerogcsclone/uimain/CalibrationsScreen.kt
@@ -1,41 +1,24 @@
 package com.example.aerogcsclone.uimain
 
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.example.aerogcsclone.navigation.Screen
 import com.example.aerogcsclone.telemetry.SharedViewModel
 
 @Composable
 fun CalibrationsScreen(
-    viewModel: SharedViewModel
+    viewModel: SharedViewModel,
+    navController: NavController
 ) {
-    val calibrationStatus by viewModel.calibrationStatus.collectAsState()
-    val imuCalibrationStartResult by viewModel.imuCalibrationStartResult.collectAsState()
-    val context = LocalContext.current
-
-    LaunchedEffect(imuCalibrationStartResult) {
-        imuCalibrationStartResult?.let { result ->
-            if (result) {
-                Toast.makeText(context, "Calibration started", Toast.LENGTH_SHORT).show()
-            } else {
-                Toast.makeText(context, "Calibration failed", Toast.LENGTH_SHORT).show()
-            }
-            viewModel.resetImuCalibrationStartResult()
-        }
-    }
-
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -63,17 +46,9 @@ fun CalibrationsScreen(
                     modifier = Modifier.padding(vertical = 8.dp)
                 )
                 Spacer(modifier = Modifier.weight(1f))
-                Button(onClick = { viewModel.startImuCalibration() }) {
-                    Text("Start IMU Calibration")
+                Button(onClick = { navController.navigate(Screen.ImuCalibration.route) }) {
+                    Text("Start")
                 }
-            }
-            calibrationStatus?.let {
-                Text(
-                    text = "Status: $it",
-                    color = Color.White,
-                    fontSize = 16.sp,
-                    modifier = Modifier.padding(top = 16.dp)
-                )
             }
         }
     }

--- a/app/src/test/java/com/example/aerogcsclone/calibration/ImuCalibrationViewModelTest.kt
+++ b/app/src/test/java/com/example/aerogcsclone/calibration/ImuCalibrationViewModelTest.kt
@@ -1,0 +1,64 @@
+package com.example.aerogcsclone.calibration
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+@ExperimentalCoroutinesApi
+class ImuCalibrationViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var viewModel: ImuCalibrationViewModel
+    private lateinit var mockCalibrationService: CalibrationService
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        mockCalibrationService = mock {
+            on { calibrationState } doReturn MutableStateFlow(CalibrationState.Idle)
+        }
+        viewModel = ImuCalibrationViewModel(mockCalibrationService)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `onStartClicked calls startImuCalibration on service`() = runTest {
+        viewModel.onStartClicked()
+        verify(mockCalibrationService).startImuCalibration()
+    }
+
+    @Test
+    fun `onPositionAcknowledged calls advanceImuCalibrationStep on service`() = runTest {
+        val awaitingUserInputState = CalibrationState.AwaitingUserInput("Place vehicle level", ImuPosition.LEVEL)
+        (mockCalibrationService.calibrationState as MutableStateFlow).value = awaitingUserInputState
+
+        viewModel.onPositionAcknowledged()
+
+        verify(mockCalibrationService).advanceImuCalibrationStep(ImuPosition.LEVEL)
+    }
+
+    @Test
+    fun `onCancelClicked calls cancelCalibration on service`() = runTest {
+        viewModel.onCancelClicked()
+        verify(mockCalibrationService).cancelCalibration()
+    }
+
+    @Test
+    fun `uiState reflects calibrationService state`() = runTest {
+        val testState = CalibrationState.InProgress("Testing")
+        (mockCalibrationService.calibrationState as MutableStateFlow).value = testState
+
+        assertEquals(testState, viewModel.uiState.value)
+    }
+}

--- a/app/src/test/java/com/example/aerogcsclone/calibration/MavlinkCalibrationServiceTest.kt
+++ b/app/src/test/java/com/example/aerogcsclone/calibration/MavlinkCalibrationServiceTest.kt
@@ -1,0 +1,90 @@
+package com.example.aerogcsclone.calibration
+
+import com.divpundir.mavlink.api.MavFrame
+import com.divpundir.mavlink.definitions.common.MavCmd
+import com.divpundir.mavlink.definitions.common.Statustext
+import com.example.aerogcsclone.telemetry.MavlinkTelemetryRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+@ExperimentalCoroutinesApi
+class MavlinkCalibrationServiceTest {
+
+    private val testScope = TestScope()
+    private lateinit var service: MavlinkCalibrationService
+    private lateinit var mockTelemetryRepository: MavlinkTelemetryRepository
+    private lateinit var mavFrameFlow: MutableSharedFlow<MavFrame<*>>
+
+    @Before
+    fun setup() {
+        mavFrameFlow = MutableSharedFlow()
+        mockTelemetryRepository = mock {
+            whenever(it.mavFrame).thenReturn(mavFrameFlow)
+        }
+        service = MavlinkCalibrationService(mockTelemetryRepository, testScope)
+    }
+
+    @Test
+    fun `startImuCalibration sends correct MAVLink command`() = testScope.runTest {
+        service.startImuCalibration()
+
+        verify(mockTelemetryRepository).sendCommandLong(
+            argThat { command.value == MavCmd.PREFLIGHT_CALIBRATION.value },
+            any(), any(), any(), argThat { this == 1.0f }, any(), any()
+        )
+    }
+
+    @Test
+    fun `cancelCalibration sends correct MAVLink command`() = testScope.runTest {
+        service.cancelCalibration()
+
+        verify(mockTelemetryRepository).sendCommandLong(
+            argThat { command.value == MavCmd.PREFLIGHT_CALIBRATION.value },
+            eq(0f), eq(0f), eq(0f), eq(0f), eq(0f), eq(0f)
+        )
+    }
+
+    @Test
+    fun `service state updates on STATUSTEXT message for user input`() = testScope.runTest {
+        service.startImuCalibration()
+
+        val statustext = Statustext.Builder().text("Place vehicle level").build()
+        mavFrameFlow.emit(MavFrame(0, 0, 0, statustext))
+
+        val state = service.calibrationState.value
+        assertTrue(state is CalibrationState.AwaitingUserInput)
+        assertEquals("Place vehicle level", (state as CalibrationState.AwaitingUserInput).instruction)
+        assertEquals(ImuPosition.LEVEL, state.visualHint)
+    }
+
+    @Test
+    fun `service state updates on STATUSTEXT message for success`() = testScope.runTest {
+        service.startImuCalibration()
+
+        val statustext = Statustext.Builder().text("Calibration successful").build()
+        mavFrameFlow.emit(MavFrame(0, 0, 0, statustext))
+
+        val state = service.calibrationState.value
+        assertTrue(state is CalibrationState.Success)
+        assertEquals("IMU Calibration Successful!", (state as CalibrationState.Success).summary)
+    }
+
+    @Test
+    fun `service state updates on STATUSTEXT message for failure`() = testScope.runTest {
+        service.startImuCalibration()
+
+        val statustext = Statustext.Builder().text("Calibration FAILED").build()
+        mavFrameFlow.emit(MavFrame(0, 0, 0, statustext))
+
+        val state = service.calibrationState.value
+        assertTrue(state is CalibrationState.Error)
+        assertEquals("IMU Calibration Failed.", (state as CalibrationState.Error).message)
+    }
+}


### PR DESCRIPTION
This commit introduces the IMU (accelerometer) calibration feature.

The implementation includes:
- A `CalibrationService` to handle the MAVLink communication for calibration procedures.
- A `MavlinkCalibrationService` implementation that sends the appropriate MAVLink commands and listens for `STATUSTEXT` messages to drive the calibration state machine.
- A `CalibrationState` sealed class to model the different states of the calibration process.
- An `ImuCalibrationViewModel` to manage the UI state and handle user interactions.
- An `ImuCalibrationScreen` composable to guide the user through the calibration steps.
- Unit tests for the `ImuCalibrationViewModel` and `MavlinkCalibrationService`.